### PR TITLE
Add support for `pyrefly`

### DIFF
--- a/src/lsp_client/capability/request.py
+++ b/src/lsp_client/capability/request.py
@@ -58,6 +58,7 @@ class WithRequestInlineCompletions(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.InlineCompletionResponse,
+            file_paths=[file_path],
         ):
             case types.InlineCompletionList(items=items) | items:
                 return items
@@ -143,6 +144,7 @@ class WithRequestReferences(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.ReferencesResponse,
+            file_paths=[file_path],
         )
 
 
@@ -189,6 +191,7 @@ class WithRequestDefinition(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.DefinitionResponse,
+            file_paths=[file_path],
         ):
             case types.Location() as location:
                 return [location]
@@ -276,6 +279,7 @@ class WithRequestHover(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.HoverResponse,
+            file_paths=[file_path],
         )
 
 
@@ -320,6 +324,7 @@ class WithRequestCallHierarchy(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.CallHierarchyPrepareResponse,
+            file_paths=[file_path],
         )
 
     async def request_call_hierarchy_incoming_call(
@@ -342,6 +347,7 @@ class WithRequestCallHierarchy(LSPCapabilityClient, Protocol):
                     params=types.CallHierarchyIncomingCallsParams(item=prepare_result),
                 ),
                 schema=types.CallHierarchyIncomingCallsResponse,
+                file_paths=[file_path],
             )
             for prepare_result in prepare_results
         )
@@ -373,6 +379,7 @@ class WithRequestCallHierarchy(LSPCapabilityClient, Protocol):
                     params=types.CallHierarchyOutgoingCallsParams(item=prepare_result),
                 ),
                 schema=types.CallHierarchyOutgoingCallsResponse,
+                file_paths=[file_path],
             )
             for prepare_result in prepare_results
         )
@@ -424,6 +431,7 @@ class WithRequestCompletions(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.CompletionResponse,
+            file_paths=[file_path],
         ):
             case types.CompletionList(items=items) | items:
                 return items
@@ -468,6 +476,7 @@ class WithRequestSignatureHelp(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.SignatureHelpResponse,
+            file_paths=[file_path],
         )
 
 
@@ -505,6 +514,7 @@ class WithRequestDocumentSymbols(LSPCapabilityClient, Protocol):
                 ),
             ),
             schema=types.DocumentSymbolResponse,
+            file_paths=[file_path],
         )
 
 

--- a/src/lsp_client/client/base.py
+++ b/src/lsp_client/client/base.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import asyncio as aio
 import inspect
 import logging
-from collections.abc import Sequence
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, ClassVar, Protocol, override
+from typing import Any, ClassVar, Protocol, Self, override
 
 from asyncio_addon import gather_all
 from lsprotocol import types
@@ -74,7 +74,7 @@ class LSPClientBase(
         server_info: LSPServerInfo | None = None,
         file_paths: Sequence[AnyPath] = (),
         pending_timeout: float | None = 5.0,
-    ):
+    ) -> AsyncGenerator[Self, Any]:
         """
         Start the LSP client.
 

--- a/src/lsp_client/client/capabilities.py
+++ b/src/lsp_client/client/capabilities.py
@@ -27,6 +27,7 @@ DEFAULT_CLIENT_CAPABILITY: ClientCapabilities = lsp_type.ClientCapabilities(
         diagnostics=lsp_type.DiagnosticWorkspaceClientCapabilities(
             refresh_support=True,
         ),
+        workspace_folders=True,
     ),
     text_document=lsp_type.TextDocumentClientCapabilities(
         synchronization=lsp_type.TextDocumentSyncClientCapabilities(

--- a/src/lsp_client/servers/pyrefly.py
+++ b/src/lsp_client/servers/pyrefly.py
@@ -1,0 +1,54 @@
+"""
+pyrefly: Type checker and language server for Python - https://pyrefly.org/
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import ClassVar, override
+
+from semver import Version
+
+from lsp_client import LSPClientBase, lsp_cap, lsp_type
+
+logger = logging.getLogger(__name__)
+
+
+class PyReflyClient(
+    lsp_cap.WithRequestReferences,
+    lsp_cap.WithRequestDocumentSymbols,
+    lsp_cap.WithRequestHover,
+    lsp_cap.WithRequestSignatureHelp,
+    lsp_cap.WithRequestCompletions,
+    lsp_cap.WithNotifyPublishDiagnostics,
+    lsp_cap.WithReceiveLogMessage,
+    lsp_cap.WithReceiveShowMessage,
+    lsp_cap.WithReceiveLogTrace,
+    LSPClientBase,
+):
+    """
+    Keep track of <https://github.com/facebook/pyrefly/issues/344> for LSP features support.
+    """
+
+    language_id: ClassVar[lsp_type.LanguageKind] = lsp_type.LanguageKind.Python
+    server_cmd: ClassVar[Sequence[str]] = (
+        "pyrefly",
+        "lsp",
+        "-v",
+    )
+
+    @override
+    @classmethod
+    def check_server_capability(
+        cls,
+        capability: lsp_type.ServerCapabilities,
+        info: lsp_type.ServerInfo | None,
+    ):
+        if info and (version := info.version):
+            assert Version.parse(version).match(">=0.24")
+
+            logger.debug(
+                "Server version %s supports PyReflyClient capabilities",
+                version,
+            )


### PR DESCRIPTION
Actually I'm very glad to find out `pyrefly` supports many LSP features like find references (not complete though), which makes it comparable to pyright and better than `ty`.