### PR TITLE
fix(utils): make DocumentSymbolPath hashable by using tuple instead of list

### DIFF
--- a/src/lsp_client/utils/symbol.py
+++ b/src/lsp_client/utils/symbol.py
@@ -38,17 +38,17 @@ class DocumentSymbolPath:
     the root symbol and proceeding through each nested child.
     """
 
-    symbols: list[DocumentSymbolName] = field(converter=list)
+    symbols: tuple[DocumentSymbolName, ...] = field(converter=tuple)
 
     @classmethod
     def from_symbols(cls, *symbol: DocumentSymbolName) -> DocumentSymbolPath:
         """Create a DocumentSymbolPath from the given sequence of symbol names."""
-        return cls(list(symbol))
+        return cls(tuple(symbol))
 
     @classmethod
     def from_str(cls, path_str: str) -> DocumentSymbolPath:
         """Create a DocumentSymbolPath from a dot-separated string representation."""
-        return cls(path_str.split("."))
+        return cls(tuple(path_str.split(".")))
 
     def format(self) -> str:
         """Return the dot-separated string representation of the path."""


### PR DESCRIPTION
## Summary
- Convert `DocumentSymbolPath.symbols` from `list` to `tuple` to make it hashable.
- Update `from_symbols` and `from_str` class methods to use tuples.
- This fixes test failures on Python 3.13 where `@frozen(hash=True)` classes with list fields raise `TypeError: unhashable type: 'list'`.