### PR TITLE
fix: ensure consistent encoding for document reading and writing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
     "anyio>=4.10.0",
     "asyncer>=0.0.10",
     "attrs>=25.3.0",
+    "charset-normalizer>=3.4.4",
     "loguru>=0.7.3",
     "lsprotocol>=2025.0.0",
     "pydantic-settings>=2.12.0",
     "semver>=3.0.4",
     "tenacity>=9.1.2",
     "xxhash>=3.6.0",
-    "charset-normalizer>=3.4.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "semver>=3.0.4",
     "tenacity>=9.1.2",
     "xxhash>=3.6.0",
+    "charset-normalizer>=3.4.1",
 ]
 
 [dependency-groups]

--- a/src/lsp_client/client/document_state.py
+++ b/src/lsp_client/client/document_state.py
@@ -74,11 +74,11 @@ class DocumentStateManager:
                 encoding = best_match.encoding
             else:
                 raise UnicodeDecodeError(
-                    "Unable to decode file content",
+                    "unknown",
                     content_bytes,
                     0,
-                    1,
-                    "unknown encoding",
+                    len(content_bytes),
+                    "Unable to decode file content",
                 )
 
             new_states[uri] = DocumentState(content, version=0, encoding=encoding)

--- a/src/lsp_client/client/document_state.py
+++ b/src/lsp_client/client/document_state.py
@@ -24,7 +24,7 @@ class DocumentState:
 
     content: str
     version: int
-    encoding: str
+    encoding: str = "utf-8"
 
 
 @define
@@ -73,12 +73,8 @@ class DocumentStateManager:
                 content = str(best_match)
                 encoding = best_match.encoding
             else:
-                raise UnicodeDecodeError(
-                    "unknown",
-                    content_bytes,
-                    0,
-                    len(content_bytes),
-                    "Unable to decode file content",
+                raise ValueError(
+                    f"Unable to decode file content for {uri}: charset detection failed"
                 )
 
             new_states[uri] = DocumentState(content, version=0, encoding=encoding)
@@ -191,7 +187,7 @@ class DocumentStateManager:
             uri: Document URI
 
         Returns:
-            Current document encoding, or None if not registered.
+            Current document encoding, or the default if not registered.
         """
         if state := self._states.get(uri):
             return state.encoding

--- a/src/lsp_client/client/document_state.py
+++ b/src/lsp_client/client/document_state.py
@@ -183,7 +183,7 @@ class DocumentStateManager:
             return state.content
         return None
 
-    def get_encoding(self, uri: str, *, default: str = "utf-8") -> str | None:
+    def get_encoding(self, uri: str, *, default: str = "utf-8") -> str:
         """
         Get current encoding of a document.
 

--- a/src/lsp_client/protocol/client.py
+++ b/src/lsp_client/protocol/client.py
@@ -60,7 +60,7 @@ class CapabilityClientProtocol(Protocol):
     async def notify(self, msg: Notification) -> None: ...
 
     @abstractmethod
-    async def read_file(self, file_path: AnyPath) -> str:
+    async def read_file(self, file_path: AnyPath, *, encoding: str = ...) -> str:
         """Read file content by path."""
 
     @abstractmethod

--- a/tests/integration/test_clients/test_workspace_edit_integration.py
+++ b/tests/integration/test_clients/test_workspace_edit_integration.py
@@ -35,11 +35,11 @@ class MockLSPClient(WithRespondApplyEdit):
     def get_document_state(self) -> DocumentStateManager:
         return self.document_state
 
-    async def read_file(self, file_path: AnyPath) -> str:
+    async def read_file(self, file_path: AnyPath, *, encoding: str = "utf-8") -> str:
         if self._temp_dir:
             path = anyio.Path(file_path)
             if await path.exists():
-                return await path.read_text()
+                return await path.read_text(encoding=encoding)
             raise FileNotFoundError(f"File not found: {file_path}")
 
         path_str = str(file_path)

--- a/tests/unit/test_capability/test_workspace_file_operations_logic.py
+++ b/tests/unit/test_capability/test_workspace_file_operations_logic.py
@@ -42,7 +42,7 @@ class MockClient:
     async def open_files(self, *file_paths):
         yield
 
-    async def read_file(self, file_path):
+    async def read_file(self, file_path, *, encoding="utf-8"):
         return ""
 
     async def write_file(self, uri, content):

--- a/tests/unit/test_protocol/test_client.py
+++ b/tests/unit/test_protocol/test_client.py
@@ -44,7 +44,7 @@ class MockClient(CapabilityClientProtocol):
     async def write_file(self, uri: str, content: str) -> None:
         pass
 
-    async def read_file(self, file_path: AnyPath) -> str:
+    async def read_file(self, file_path: AnyPath, *, encoding: str = "utf-8") -> str:
         return ""
 
     async def request[R](self, req: Request, schema: type[Response[R]]) -> R:

--- a/tests/unit/test_utils/test_workspace_edit.py
+++ b/tests/unit/test_utils/test_workspace_edit.py
@@ -54,12 +54,12 @@ class MockClient(CapabilityClientProtocol):
     async def notify(self, msg: Notification) -> None:
         pass
 
-    async def read_file(self, file_path: AnyPath) -> str:
+    async def read_file(self, file_path: AnyPath, *, encoding: str = "utf-8") -> str:
         if self._temp_dir:
             # Read from actual filesystem if temp_dir is set
             path = anyio.Path(file_path)
             if await path.exists():
-                return await path.read_text()
+                return await path.read_text(encoding=encoding)
             raise FileNotFoundError(f"File not found: {file_path}")
 
         path_str = str(file_path)


### PR DESCRIPTION
## Summary
- Added `charset-normalizer` to automatically detect file encoding when reading documents.
- Stored encoding in `DocumentState` to ensure the same encoding is used when writing back to disk.
- Updated `read_file` and `write_file` in `Client` to support and respect document encoding.
- This prevents potential corruption when dealing with non-UTF-8 files.